### PR TITLE
[#30] Fix JwtUtil.validateToken parsing

### DIFF
--- a/services-auth/src/main/kotlin/com/yourssu/morupark/auth/util/JwtUtil.kt
+++ b/services-auth/src/main/kotlin/com/yourssu/morupark/auth/util/JwtUtil.kt
@@ -27,6 +27,7 @@ class JwtUtil(
             Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
+                .parseSignedClaims(token)
         } catch (_: JwtException) {
             return false
         }


### PR DESCRIPTION
## 요약
- `JwtUtil.validateToken`이 parser만 생성해 서명/만료 검증이 수행되지 않던 버그를 수정했습니다.
- `parseSignedClaims(token)`을 호출해 서명/만료/형식까지 실제 검증을 진행하도록 변경했습니다.
- 검증 실패 시 `JwtException`을 잡아 `false`를 반환하는 기존 동작은 유지했습니다.
