### PR TITLE
[#31] JWT 검증 필터 추가

### DIFF
--- a/services-auth/build.gradle.kts
+++ b/services-auth/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
+
+    testImplementation("io.mockk:mockk:1.13.13")
 }

--- a/services-auth/src/main/kotlin/com/yourssu/morupark/auth/config/SecurityConfig.kt
+++ b/services-auth/src/main/kotlin/com/yourssu/morupark/auth/config/SecurityConfig.kt
@@ -1,25 +1,46 @@
 package com.yourssu.morupark.auth.config
 
+import com.yourssu.morupark.auth.config.filter.JwtAuthenticationFilter
+import com.yourssu.morupark.auth.config.properties.JwtProperties
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        http.csrf { csrf ->
-            csrf.ignoringRequestMatchers("/**")
-        }
-        .authorizeHttpRequests { requests ->
-            requests
-                .requestMatchers("/**").permitAll()
-                .anyRequest().authenticated()
-        }
+    fun filterChain(
+        http: HttpSecurity,
+        jwtProperties: JwtProperties,
+    ): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { requests ->
+                requests
+                    .requestMatchers("/external-servers/**", "/auth/token/**").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint { _, response, _ ->
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")
+                    }
+                    .accessDeniedHandler { _, response, _ ->
+                        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden")
+                    }
+            }
+            .addFilterBefore(
+                JwtAuthenticationFilter(jwtProperties),
+                UsernamePasswordAuthenticationFilter::class.java,
+            )
 
         return http.build()
     }

--- a/services-auth/src/main/kotlin/com/yourssu/morupark/auth/config/filter/JwtAuthenticationFilter.kt
+++ b/services-auth/src/main/kotlin/com/yourssu/morupark/auth/config/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,52 @@
+package com.yourssu.morupark.auth.config.filter
+
+import com.yourssu.morupark.auth.config.properties.JwtProperties
+import com.yourssu.morupark.auth.util.JwtUtil
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.web.filter.OncePerRequestFilter
+
+class JwtAuthenticationFilter(
+    jwtProperties: JwtProperties,
+) : OncePerRequestFilter() {
+    private val jwtUtil = JwtUtil(jwtProperties.secret, jwtProperties.accessTokenExpiration)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val authHeader = request.getHeader("Authorization")
+        if (authHeader.isNullOrBlank()) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        if (!authHeader.startsWith("Bearer ")) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Authorization header")
+            return
+        }
+
+        val token = authHeader.substringAfter("Bearer ").trim()
+        if (token.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Missing token")
+            return
+        }
+
+        if (!jwtUtil.validateToken(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token")
+            return
+        }
+
+        val userId = jwtUtil.getUserIdFromToken(token)
+        val authentication = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+        authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
+        SecurityContextHolder.getContext().authentication = authentication
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/services-auth/src/test/kotlin/com/yourssu/morupark/auth/config/filter/JwtAuthenticationFilterTest.kt
+++ b/services-auth/src/test/kotlin/com/yourssu/morupark/auth/config/filter/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,91 @@
+package com.yourssu.morupark.auth.config.filter
+
+import com.yourssu.morupark.auth.config.properties.JwtProperties
+import com.yourssu.morupark.auth.util.JwtUtil
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.core.context.SecurityContextHolder
+
+@ExtendWith(MockKExtension::class)
+class JwtAuthenticationFilterTest {
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var request: HttpServletRequest
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var response: HttpServletResponse
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var filterChain: FilterChain
+
+    private val jwtProperties = JwtProperties(
+        secret = "a".repeat(64),
+        accessTokenExpiration = 3_600_000,
+    )
+    private val jwtUtil = JwtUtil(jwtProperties.secret, jwtProperties.accessTokenExpiration)
+    private val filter = JwtAuthenticationFilter(jwtProperties)
+
+    @BeforeEach
+    fun setup() {
+        SecurityContextHolder.clearContext()
+        every { request.getAttribute(any()) } returns null
+        every { request.dispatcherType } returns DispatcherType.REQUEST
+        every { request.remoteAddr } returns "127.0.0.1"
+        every { request.session } returns null
+        every { request.getSession(any()) } returns null
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `유효한 Bearer 토큰이면 SecurityContext에 userId가 설정되고 체인이 실행된다`() {
+        val userId = 123L
+        val token = jwtUtil.generateToken(userId)
+
+        every { request.getHeader("Authorization") } returns "Bearer $token"
+
+        filter.doFilter(request, response, filterChain)
+
+        val authentication = SecurityContextHolder.getContext().authentication
+        assert(authentication?.principal == userId)
+        verify(exactly = 1) { filterChain.doFilter(request, response) }
+        verify(exactly = 0) { response.sendError(any(), any()) }
+    }
+
+    @Test
+    fun `Authorization 헤더가 없으면 인증 없이 체인이 그대로 실행된다`() {
+        every { request.getHeader("Authorization") } returns null
+
+        filter.doFilter(request, response, filterChain)
+
+        val authentication = SecurityContextHolder.getContext().authentication
+        assert(authentication == null)
+        verify(exactly = 1) { filterChain.doFilter(request, response) }
+        verify(exactly = 0) { response.sendError(any(), any()) }
+    }
+
+    @Test
+    fun `유효하지 않은 토큰이면 401을 반환하고 체인이 중단된다`() {
+        every { request.getHeader("Authorization") } returns "Bearer invalid.token.value"
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(exactly = 1) { response.sendError(HttpServletResponse.SC_UNAUTHORIZED, any()) }
+        verify(exactly = 0) { filterChain.doFilter(request, response) }
+        val authentication = SecurityContextHolder.getContext().authentication
+        assert(authentication == null)
+    }
+}


### PR DESCRIPTION
## 요약
- JWT 인증 필터를 추가해 Bearer 토큰을 추출·검증 후 SecurityContext에 인증 정보를 설정합니다.
- SecurityConfig에 필터를 등록하고 공개 엔드포인트(`/external-servers/**`, `/auth/token/**`)만 허용하며 나머지는 인증을 요구합니다.
- MockK 기반 테스트로 유효/무효/미제공 토큰 케이스를 검증합니다.

## 테스트
- ./gradlew :services-auth:test