### PR TITLE
[#79]; fix: status 조회 시 간헐적 401 발생

### DIFF
--- a/services-queue/src/main/kotlin/com/yourssu/morupark/queue/business/QueueService.kt
+++ b/services-queue/src/main/kotlin/com/yourssu/morupark/queue/business/QueueService.kt
@@ -33,13 +33,13 @@ class QueueService(
 
     fun getStatus(waitingToken: String): TicketStatusResponse {
         if (queueAdapter.isInQueue(waitingToken)) {
-            return getWaitingStatusResult(waitingToken)
+            return getWaitingStatusResult(waitingToken) ?: getStatusResult(waitingToken)
         }
         return getStatusResult(waitingToken)
     }
 
-    private fun getWaitingStatusResult(waitingToken: String): TicketStatusResponse {
-        val rank = queueAdapter.getRank(waitingToken)!!
+    private fun getWaitingStatusResult(waitingToken: String): TicketStatusResponse? {
+        val rank = queueAdapter.getRank(waitingToken) ?: return null
         val estimatedWaitSeconds = waitingTimeEstimator.estimateWaitingTime(rank)
         return TicketStatusResponse(
             status = TicketStatus.WAITING,

--- a/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/QueueAdapter.kt
+++ b/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/QueueAdapter.kt
@@ -20,12 +20,13 @@ class QueueAdapter(
         redisTemplate.opsForHash<String, String>().put(USER_HASH_KEY, waitingToken, "$studentId|$phoneNumber")
     }
 
-    fun popFromWaitingQueue(count: Long): Set<String>? {
-        val items = redisTemplate.opsForZSet().range(WAITING_KEY, 0, count - 1)
-        if (!items.isNullOrEmpty()) {
-            redisTemplate.opsForZSet().remove(WAITING_KEY, *items.toTypedArray())
-        }
-        return items
+    fun peekFromWaitingQueue(count: Long): Set<String>? {
+        return redisTemplate.opsForZSet().range(WAITING_KEY, 0, count - 1)
+    }
+
+    fun removeFromWaitingQueue(waitingTokens: Set<String>) {
+        if (waitingTokens.isEmpty()) return
+        redisTemplate.opsForZSet().remove(WAITING_KEY, *waitingTokens.toTypedArray())
     }
 
     fun getUserInfo(waitingToken: String): String? {
@@ -48,12 +49,8 @@ class QueueAdapter(
         return redisTemplate.opsForHash<String, String>().get(STATUS_HASH_KEY, waitingToken)
     }
 
-    fun popAllFromWaitingQueue(): Set<String>? {
-        val items = redisTemplate.opsForZSet().range(WAITING_KEY, 0, -1)
-        if (!items.isNullOrEmpty()) {
-            redisTemplate.opsForZSet().remove(WAITING_KEY, *items.toTypedArray())
-        }
-        return items
+    fun peekAllFromWaitingQueue(): Set<String>? {
+        return redisTemplate.opsForZSet().range(WAITING_KEY, 0, -1)
     }
 
     fun saveSoldOut(goodsId: Long) {

--- a/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/StatusOperator.kt
+++ b/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/StatusOperator.kt
@@ -18,12 +18,16 @@ class StatusOperator(
 
     @Scheduled(fixedDelayString = "\${queue.processing-interval}")
     fun processQueue() {
-        val waitingTokens = queueAdapter.popFromWaitingQueue(maxSize)
+        val waitingTokens = queueAdapter.peekFromWaitingQueue(maxSize)
         if (waitingTokens.isNullOrEmpty()) return
 
         log.info("[SCHEDULER] 처리 시작 - 대상 수: ${waitingTokens.size}")
         for (waitingToken in waitingTokens) {
             queueAdapter.saveStatus(waitingToken, TicketStatus.PROCESSING.name)
+        }
+        queueAdapter.removeFromWaitingQueue(waitingTokens)
+
+        for (waitingToken in waitingTokens) {
             val userInfo = queueAdapter.getUserInfo(waitingToken) ?: continue
             val (studentId, phoneNumber) = userInfo.split("|")
             log.info("[SCHEDULER] Kafka 발행 - token: $waitingToken, studentId: $studentId")

--- a/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/TicketResultConsumer.kt
+++ b/services-queue/src/main/kotlin/com/yourssu/morupark/queue/implement/TicketResultConsumer.kt
@@ -30,11 +30,12 @@ class TicketResultConsumer(
         if (message.startsWith("SOLD_OUT:")) {
             val goodsId = message.removePrefix("SOLD_OUT:").toLongOrNull() ?: return
             queueAdapter.saveSoldOut(goodsId)
-            val remaining = queueAdapter.popAllFromWaitingQueue()
-            log.warn("[CONSUMER] SOLD_OUT(goodsId=$goodsId) - 잔여 대기자 FAILED 처리: ${remaining?.size ?: 0}명")
-            remaining?.forEach { token ->
+            val remaining = queueAdapter.peekAllFromWaitingQueue().orEmpty()
+            log.warn("[CONSUMER] SOLD_OUT(goodsId=$goodsId) - 잔여 대기자 FAILED 처리: ${remaining.size}명")
+            remaining.forEach { token ->
                 queueAdapter.saveStatus(token, "${TicketStatus.FAILED.name}:${FailureReason.SOLD_OUT.name}")
             }
+            queueAdapter.removeFromWaitingQueue(remaining)
             return
         }
 


### PR DESCRIPTION
Closes #79

## 변경 요약
- `StatusOperator.processQueue`: PROCESSING 저장 후 ZSet 제거 순서로 변경
- `TicketResultConsumer` SOLD_OUT 처리도 동일 순서로 정리
- `QueueService.getRank()` 강제 언래핑 제거, race 시 결과 저장소로 폴백
- `QueueAdapter`: pop을 peek + remove로 분리