### PR TITLE
[#81]; fix: 굿즈 서비스 중복 메시지 처리 방지

### DIFF
--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/business/GoodsService.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/business/GoodsService.kt
@@ -1,5 +1,6 @@
 package com.yourssu.morupark.goods.business
 
+import com.yourssu.morupark.goods.implement.TicketDeduplicator
 import com.yourssu.morupark.goods.implement.TicketProcessor
 import com.yourssu.morupark.goods.implement.TicketValidator
 import org.slf4j.LoggerFactory
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class GoodsService(
     private val ticketValidator: TicketValidator,
     private val ticketProcessor: TicketProcessor,
+    private val ticketDeduplicator: TicketDeduplicator,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -27,6 +29,11 @@ class GoodsService(
 
     @Transactional
     fun processTicket(waitingToken: String, studentId: String, phoneNumber: String) {
+        if (ticketDeduplicator.isDuplicate(waitingToken)) {
+            log.warn("[SERVICE] 중복 메시지 감지 - token: $waitingToken")
+            return
+        }
+
         if (ticketValidator.isSoldOut(GOODS_ID)) {
             log.warn("[SERVICE] 재고 없음 - token: $waitingToken")
             eventPublisher.publishEvent(TicketFailedEvent(waitingToken, FailureReason.SOLD_OUT))

--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/implement/ProcessedTicketRepository.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/implement/ProcessedTicketRepository.kt
@@ -1,0 +1,6 @@
+package com.yourssu.morupark.goods.implement
+
+interface ProcessedTicketRepository {
+    fun existsByToken(waitingToken: String): Boolean
+    fun save(waitingToken: String)
+}

--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/implement/TicketDeduplicator.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/implement/TicketDeduplicator.kt
@@ -1,0 +1,19 @@
+package com.yourssu.morupark.goods.implement
+
+import org.springframework.stereotype.Component
+
+@Component
+class TicketDeduplicator(
+    private val processedTicketRepository: ProcessedTicketRepository,
+) {
+    /**
+     * 토큰의 중복 처리 여부를 확인한다.
+     * 처음 보는 토큰이면 처리 기록을 저장하고 false를 반환한다.
+     * 이미 처리된 토큰이면 true를 반환한다.
+     */
+    fun isDuplicate(waitingToken: String): Boolean {
+        if (processedTicketRepository.existsByToken(waitingToken)) return true
+        processedTicketRepository.save(waitingToken)
+        return false
+    }
+}

--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/JpaProcessedTicketRepository.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/JpaProcessedTicketRepository.kt
@@ -1,0 +1,5 @@
+package com.yourssu.morupark.goods.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaProcessedTicketRepository : JpaRepository<ProcessedTicketEntity, String>

--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/ProcessedTicketEntity.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/ProcessedTicketEntity.kt
@@ -1,0 +1,22 @@
+package com.yourssu.morupark.goods.storage
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.domain.Persistable
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "processed_ticket")
+class ProcessedTicketEntity(
+    @Id
+    @Column(name = "waiting_token")
+    val waitingToken: String,
+
+    @Column(name = "processed_at", nullable = false)
+    val processedAt: LocalDateTime = LocalDateTime.now(),
+) : Persistable<String> {
+    override fun getId(): String = waitingToken
+    override fun isNew(): Boolean = true
+}

--- a/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/ProcessedTicketRepositoryImpl.kt
+++ b/services-goods/src/main/kotlin/com/yourssu/morupark/goods/storage/ProcessedTicketRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.yourssu.morupark.goods.storage
+
+import com.yourssu.morupark.goods.implement.ProcessedTicketRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProcessedTicketRepositoryImpl(
+    private val jpaProcessedTicketRepository: JpaProcessedTicketRepository,
+) : ProcessedTicketRepository {
+
+    override fun existsByToken(waitingToken: String): Boolean =
+        jpaProcessedTicketRepository.existsById(waitingToken)
+
+    override fun save(waitingToken: String) {
+        jpaProcessedTicketRepository.save(ProcessedTicketEntity(waitingToken))
+    }
+}

--- a/services-goods/src/test/kotlin/com/yourssu/morupark/goods/unit/GoodsServiceTest.kt
+++ b/services-goods/src/test/kotlin/com/yourssu/morupark/goods/unit/GoodsServiceTest.kt
@@ -1,6 +1,7 @@
 package com.yourssu.morupark.goods.unit
 
 import com.yourssu.morupark.goods.business.*
+import com.yourssu.morupark.goods.implement.TicketDeduplicator
 import com.yourssu.morupark.goods.implement.TicketProcessor
 import com.yourssu.morupark.goods.implement.TicketValidator
 import io.mockk.*
@@ -22,6 +23,9 @@ class GoodsServiceTest {
     private lateinit var ticketProcessor: TicketProcessor
 
     @MockK
+    private lateinit var ticketDeduplicator: TicketDeduplicator
+
+    @MockK
     private lateinit var eventPublisher: ApplicationEventPublisher
 
     @InjectMockKs
@@ -35,6 +39,7 @@ class GoodsServiceTest {
     fun `이미 품절된 경우 당첨 판정 없이 SOLD_OUT 실패 이벤트를 발행한다`() {
         // given
         val events = mutableListOf<Any>()
+        every { ticketDeduplicator.isDuplicate(waitingToken) } returns false
         every { ticketValidator.isSoldOut(any()) } returns true
         every { eventPublisher.publishEvent(capture(events)) } just runs
 
@@ -51,6 +56,7 @@ class GoodsServiceTest {
     fun `낙첨 시 LOST 실패 이벤트를 발행한다`() {
         // given
         val events = mutableListOf<Any>()
+        every { ticketDeduplicator.isDuplicate(waitingToken) } returns false
         every { ticketValidator.isSoldOut(any()) } returns false
         every { ticketValidator.isWinner() } returns false
         every { eventPublisher.publishEvent(capture(events)) } just runs
@@ -66,6 +72,7 @@ class GoodsServiceTest {
     @Test
     fun `당첨 시 TicketProcessor에 처리를 위임한다`() {
         // given
+        every { ticketDeduplicator.isDuplicate(waitingToken) } returns false
         every { ticketValidator.isSoldOut(any()) } returns false
         every { ticketValidator.isWinner() } returns true
         every { ticketProcessor.process(any(), any(), any(), any()) } just runs
@@ -75,5 +82,20 @@ class GoodsServiceTest {
 
         // then
         verify { ticketProcessor.process(waitingToken, studentId, phoneNumber, 1L) }
+    }
+
+    @Test
+    fun `이미 처리된 토큰은 무시하고 어떤 분기도 타지 않는다`() {
+        // given
+        every { ticketDeduplicator.isDuplicate(waitingToken) } returns true
+
+        // when
+        goodsService.processTicket(waitingToken, studentId, phoneNumber)
+
+        // then
+        verify(exactly = 0) { ticketValidator.isSoldOut(any()) }
+        verify(exactly = 0) { ticketValidator.isWinner() }
+        verify(exactly = 0) { ticketProcessor.process(any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any()) }
     }
 }


### PR DESCRIPTION
Closes #81

## 변경 요약
- `TicketDeduplicator` 컴포넌트 추가 (`isDuplicate(token)` — 처음 호출이면 기록 저장 후 false, 이미 처리됐으면 true)
- `processed_ticket` 테이블/엔티티/레포지토리 신설
- `GoodsService.processTicket` 진입부에서 중복 토큰이면 즉시 return (재고 차감/winner 저장/이벤트 발행 모두 스킵)
- 테스트 보강: 중복 토큰 호출 시 어떤 분기도 타지 않음을 검증